### PR TITLE
Roadmap, Scope and Actions for v1.0

### DIFF
--- a/INTERESTED_DEVELOPERS.md
+++ b/INTERESTED_DEVELOPERS.md
@@ -1,9 +1,19 @@
-# Interested Developers:
-This file will help us track people that are interested in taking decisions of the specification of GraphQL over HTTP until migrated to a official repository of the https://github.com/graphql organization.
+# Interested Developers
+
+## Want to get involved? 
+
+If you're interested in this spec and helping contribute to it, you can get involved with the following steps:
+
+1. Read the [Roadmap](ROADMAP.md) which outlines the planned development of this spec.
+2. See [Agendas](agendas) for upcoming meetings of the GraphQL-over-HTTP working group.
+3. Add yourself to `List of Developers` below.
+
+## List of Developers
+
+This list helps us keep track people that are interested in taking decisions of the specification of GraphQL over HTTP.
 
 If you want to be listed here, open a PR with your information, just order yourself by name.
 
-## List of Developers:
 * @benjie
   * Company/Project/Repo: https://github.com/graphql/graphiql, https://github.com/graphile/postgraphile
   * Reason: Interested in a common HTTP spec
@@ -35,5 +45,6 @@ If you want to be listed here, open a PR with your information, just order yours
   * Company/Project/Repo: https://github.com/graphql-dotnet/server
   * Reason: Interested in client/server spec
 
-## CC Helper:
-CC: @benjie @deinok @erikwittern @jaydenseric @michaelstaib @mike-marcacci @mmatsa @sjparsons @spawnia @sungam3r
+### CC Helper
+
+`@benjie @deinok @erikwittern @jaydenseric @michaelstaib @mike-marcacci @mmatsa @sjparsons @spawnia @sungam3r`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
+> **Stage 1: Proposal** 
+> 
+> This spec is under active development. For more information, please see the [Roadmap](ROADMAP.md) or [how to get involved](INTERESTED_DEVELOPERS.md).
+
+---
+
 # GraphQL over HTTP
 
-*Current Working Draft*
+
 
 **Introduction**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,38 @@
+# GraphQL over HTTP Spec Roadmap
+
+The GraphQL over HTTP working group is a sub group of the GraphQL working group. Our aim is to prepare and public version 1.0 of this spec.
+
+## Version 1.0
+
+### Goal
+
+Provide a spec that allows clients and servers with different implementations and technology stacks to interact freely over HTTP if both client and server are compliant with the GraphQL over HTTP spec.
+
+### Scope
+
+_Under active discussion_
+
+- Status codes
+  - document the currently supported edge cases in common implementations
+
+
+- Test suite 
+  - Alongside the spec itself, provide a test suite that should pass if a server implements the spec
+
+### Actions
+
+_Under active discussion_
+
+- [ ] Review existing implementations over HTTP and consider if there are standards that can be documented and extracted
+- [ ] Update links to point to the GraphQL Foundation repos and websites not FB
+- [ ] Copyright notice
+
+### Open questions
+
+- Current spec is agnostic about serialization format. Is there are good reason not to at least specify that a compliant client/server should implement JSON as a minimum? 
+- Should details on how Subscriptions work over HTTP be given in this spec 1.0?
+
+
+## Future
+
+_Placeholder for scope and actions that do not fit into version 1.0_


### PR DESCRIPTION
This PR begins a Roadmap document with some initial items under scope and actions for v1.0. My intention is to collaboratively edit the scope and actions as part of the November meeting of the GraphQL over HTTP working group. After that, this PR will be updated to reflect the results.

Easy links for viewing updated files:
 - [Roadmap](https://github.com/sjparsons/graphql-over-http/blob/roadmap-draft/ROADMAP.md)
 - [Interested Developers](https://github.com/sjparsons/graphql-over-http/blob/roadmap-draft/INTERESTED_DEVELOPERS.md)
 - [Spec](https://github.com/sjparsons/graphql-over-http/blob/roadmap-draft/README.md) (The only change is the the note at the top stating the status and linking to the ROADMAP)