### PR TITLE
SP: Discuss scope/action plan for v1.0 of spec

### DIFF
--- a/agendas/2019-11-21.md
+++ b/agendas/2019-11-21.md
@@ -24,6 +24,7 @@ This is an open meeting in which anyone in the GraphQL community may attend.
 | ------------------------ | ------------------------ | ------------------------
 | Ivan Goncharov           | GraphQL Foundation       | Lviv, UA
 | Benedikt Franke          | Lighthouse               | Munich, Germany
+| Sam Parsons              | PayPal                   | Ames, IA, USA
 | Vladimir Razuvaev        | graphql-php              | Tomsk, Russia
 | *ADD YOUR NAME ABOVE TO ATTEND*
 
@@ -49,5 +50,7 @@ Example agenda item:
 1. Determine volunteers for note taking (2m, Ivan)
 1. Review agenda (2m, Ivan)
 1. Motivation for "GraphQL Over HTTP" spec and its current state (15m, Ivan)
+1. First release of GraphQL-over-HTTP spec: scope and action plan (30m, Sam)
+   - See the [Roadmap PR](https://github.com/APIs-guru/graphql-over-http/pull/24) containing a starter for our discussion
 1. Modularity and opt-in features (10m, Benedikt)
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
Add agenda item to discuss scope/action plan for v1.0 of the spec at the November **GraphQL over HTTP** working group.