### PR TITLE
Publish schedule and re-organize

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,5 @@
 # GraphQL over HTTP Spec Roadmap
 
-The GraphQL over HTTP working group is a sub group of the GraphQL working group. Our aim is to prepare and publish version 1.0 of this spec.
-
 ## Version 1.0
 
 ### Goal

--- a/working-group/README.md
+++ b/working-group/README.md
@@ -1,0 +1,10 @@
+# GraphQL over HTTP working group
+
+The GraphQL over HTTP working group is a sub group of the GraphQL working group. The current goals are laid out in the [Roadmap](../ROADMAP.md).
+
+## Meetings
+
+> **Last Tuesday of the month at 19:00 - 21:00 UTC**
+
+See [Agendas](Agendas) for upcoming scheduled meetings and notes from previous meetings.
+

--- a/working-group/agendas/2019-11-21.md
+++ b/working-group/agendas/2019-11-21.md
@@ -78,7 +78,7 @@ Example agenda item:
 - [ ] List of GraphQL server libs (@sjparsons to create template, others can PR and add more)
 - [ ] List of public GraphQL Apis (Github, Shopify, etc) (@sjparsons to create template, others can PR and add more)
 - [ ] List of possible 'specs' such as multipart, batching, subscription, etc (@sjparsons to create template, others can PR and add more)
-- [ ] Publish the schedule (@sjparsons)
+- [x] Publish the schedule (@sjparsons)
 
 ## Next meetings
 

--- a/working-group/agendas/2019-12-17.md
+++ b/working-group/agendas/2019-12-17.md
@@ -1,0 +1,50 @@
+# GraphQL over HTTP WG – December 2019
+
+The GraphQL over HTTP Working Group meets monthly to discuss proposed additions
+to the GraphQL over HTTP Specification and other relevant topics.
+This is an open meeting in which anyone in the GraphQL community may attend.
+*To attend this meeting or propose agenda, edit this file.*
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [December 17th 2019 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=12&day=17&hour=19&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152).
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+
+| Name                     | Organization / Project         | Location
+| ------------------------ | ------------------------------ | ---------
+| *ADD YOUR NAME ABOVE TO ATTEND, ORDER BY ORG THEN NAME*
+
+## Agenda
+
+> **Guidelines**
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Introduction of attendees (5m)
+1. Determine volunteers for note taking (2m)
+1. Review agenda (2m)
+
+1. *ADD YOUR AGENDA ABOVE*
+

--- a/working-group/agendas/_template.md
+++ b/working-group/agendas/_template.md
@@ -1,0 +1,50 @@
+# GraphQL over HTTP WG – <MONTH> <YEAR>
+
+The GraphQL over HTTP Working Group meets monthly to discuss proposed additions
+to the GraphQL over HTTP Specification and other relevant topics.
+This is an open meeting in which anyone in the GraphQL community may attend.
+*To attend this meeting or propose agenda, edit this file.*
+
+- **Video Conference Link**: TBD
+- **Live Notes**: TBD
+- **Date & Time**: [MONTH DAY YEAR 17:00 - 20:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2019&month=11&day=21&hour=17&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152).
+
+  <small>*NOTE:* Meeting date and time may change. Please check this agenda the week of the meeting to confirm.</small>
+
+## Attendees
+
+> **Guidelines**
+> - Before attending, you (or your organization) must sign the [Specification Membership Agreement](https://github.com/graphql/foundation).
+> - To respect meeting size, attendees should be relevant to the agenda.
+> - If you're willing to take notes, add "✏️" after your name (eg. Ada Lovelace)
+> - Include the organization (or project) you represent, and the location (including [country code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes#Current_ISO_3166_country_codes)) you expect to be located in during the meeting.
+> - Read and follow the [participation guidelines](https://github.com/graphql/graphql-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
+
+| Name                     | Organization / Project         | Location
+| ------------------------ | ------------------------------ | ---------
+| *ADD YOUR NAME ABOVE TO ATTEND, ORDER BY ORG THEN NAME*
+
+## Agenda
+
+> **Guidelines**
+> - To cover everything, discussion may be time-constrained. Topics that require less time should be covered first. Most topics take 15-30 minutes.
+> - Include any and all relevant links (RFC, issues & PRs, presentations). If there are no relevant links, open an issue to provide context and link to that.
+> - Read the [spec contribution guide](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+
+<!--
+
+Example agenda item:
+
+1. Discuss moving the subscriptions proposal to stage 2 (30m, Lee)
+   - [Subscriptions RFC](link.to/the-relevant/pr-or-issue-or-doc)
+   - [GraphQL.js PR](github.link/to/the/project/pr)
+   - [Another Relevant Link](youre.getting/the-idea.now)
+
+-->
+
+1. Introduction of attendees (5m)
+1. Determine volunteers for note taking (2m)
+1. Review agenda (2m)
+
+1. *ADD YOUR AGENDA ABOVE*
+


### PR DESCRIPTION
This PR publishes the general schedule for the working group and sets up a folder for future files related to the working-group itself. 