### PR TITLE
Update the implementation lists

### DIFF
--- a/working-group/implementations.md
+++ b/working-group/implementations.md
@@ -69,6 +69,7 @@ This broadly includes GraphQL servers, clients, middleware, SDK level libraries 
 | [Altair](https://github.com/imolorhe/altair)                                  | TypeScript | 1900  |
 | [Lokka](https://github.com/kadirahq/lokka)                                    | JavaScript | 1486  |
 | [graphql-hooks](https://github.com/nearform/graphql-hooks)                    | JavaScript | 1045  |
+| [apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client)   | JavaScript | 859   |
 | [graphql-react](https://github.com/jaydenseric/graphql-react)                 | JavaScript | 482   |
 | [machinebox/graphql](https://github.com/machinebox/graphql)                   | Go         | 473   |
 | [nanographql](https://github.com/yoshuawuyts/nanographql)                     | JavaScript | 360   |

--- a/working-group/implementations.md
+++ b/working-group/implementations.md
@@ -1,76 +1,84 @@
 # GraphQL over HTTP Implementations
 
-The following is a list of existing server and client implementations of GraphQL over HTTP. The goal of this document is to help the working-group identify common patterns in doing GraphQL over HTTP. To that end we only list here _popular_ HTTP servers and clients. If you're looking for a canonical list of implementations, see [Graphql - Code](https://graphql.org/code/). To be included here, the server or client MUST at least support GraphQL over HTTP, although it MAY support other transport protocols and it MUST be _popular_.
+The following is a list of popular server and client implementations of GraphQL over HTTP.
 
-**Definition: "_Popular_"**
+The goal of this document is to help the working-group identify common patterns in doing GraphQL over HTTP. To that end only _popular_ _implementations_ are listed here. If you're looking for a canonical list, see [graphql.org/code](https://graphql.org/code).
 
-> The project has more than 100 stars on its GitHub repo. 
+#### Definition: _"Popular"_
 
-Though it's not a perfect measure, it is a commonly accessible measure get a sense of how popular a library or project is.
+> The project has more than 100 stars on its GitHub repo.
 
-## Popular Servers
+Though it's not a perfect measure, it's a commonly accessible measure get a sense of how popular a library or project is.
 
-| Name | Language | ⭐️ |
-|---|---|---|
-| [apollo-server](https://github.com/apollographql/apollo-server) | JavaScript | 8500
-| [graphql](https://github.com/graphql-go/graphql) | Go | 5700
-| [Graphene](https://github.com/graphql-python/graphene) | Python | 5200
-| [graphql-yoga](https://github.com/prisma-labs/graphql-yoga) | TypeScript | 5100
-| [express-graphql](https://github.com/graphql/express-graphql) | JavaScript | 4900
-| [graphql-ruby](https://github.com/rmosolgo/graphql-ruby) | Ruby | 4000
-| [graphql-java](https://github.com/graphql-java/graphql-java) | Java | 3800
-| [GraphQL for .NET](https://github.com/graphql-dotnet/graphql-dotnet) | C#/.NET | 3800
-| [gqlgen](https://github.com/99designs/gqlgen) | Go | 3600
-| [graphql-php](https://github.com/webonyx/graphql-php) | PHP | 3400
-| [absinthe](https://github.com/absinthe-graphql/absinthe) | Elixir | 3000
-| [graphql-go](https://github.com/graph-gophers/graphql-go) | Go | 3000
-| [Juniper](https://github.com/graphql-rust/juniper) | Rust | 1900
-| [Sangria](https://github.com/sangria-graphql/sangria) | Scala | 1600
-| [Lighthouse](https://github.com/nuwave/lighthouse) | PHP/Laravel | 1400
-| [lacinia](https://github.com/walmartlabs/lacinia) | Clojure | 1300
-| [graphql-laravel](https://github.com/rebing/graphql-laravel) | PHP/Laravel | 1100
-| [Thunder](https://github.com/samsarahq/thunder) | Go | 914
-| [graphql-elixir](https://github.com/graphql-elixir/graphql) | Elixir | 837
-| [Siler](https://github.com/leocavalcante/siler) | PHP | 837
-| [GraphQL.Net](https://github.com/chkimes/graphql-net) | C#/.NET | 795
-| [Hot Chocolate](https://github.com/ChilliCream/hotchocolate) | C# | 736
-| [koa-graphql](https://github.com/chentsulin/koa-graphql) | JavaScript | 719
-| [tartiflette](https://github.com/tartiflette/tartiflette) | Python | 487
-| [graphql-kotlin](https://github.com/ExpediaGroup/graphql-kotlin/) | Kotlin | 336
-| [graphql-relay-go](https://github.com/graphql-go/relay) | Go | 331
-| [graphql-clj](https://github.com/tendant/graphql-clj) | Clojure | 267
-| [graphql-erlang](https://github.com/shopgun/graphql-erlang) | Erlang | 254
-| [Alumbra](https://github.com/alumbra/alumbra) | Clojure | 135
+#### Definition: _"Implementation"_
 
-⭐️ accurate as of November 2019
+> Published software that interacts with GraphQL over HTTP.
 
-## Popular Clients
+This broadly includes GraphQL servers, clients, middleware, SDK level libraries and IDEs. To be listed, it **must** at least support GraphQL over HTTP, although it **may** support other transport protocols.
 
-| Name | Language | ⭐️ |
-|---|---|---|
-| [Relay](https://github.com/facebook/relay) | JavaScript | 13800
-| [apollo-client](https://github.com/apollographql/apollo-client) | TypeScript | 12600
-| [graphiql](https://github.com/graphql/graphiql) | JavaScript | 9600
-| [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) | TypeScript | 5400
-| [graphql-editor](https://github.com/graphql-editor/graphql-editor) | TypeScript | 4100
-| [urql](https://github.com/FormidableLabs/urql) | TypeScript | 3800
-| [Apollo iOS](https://github.com/apollographql/apollo-ios) | Swift | 2200
-| [graphql-request](https://github.com/prisma-labs/graphql-request) | TypeScript | 2000
-| [apollo-android](https://github.com/apollographql/apollo-android) | Java | 2000
-| [Altair](https://github.com/imolorhe/altair) | TypeScript | 1800
-| [Lokka](https://github.com/kadirahq/lokka) | JavaScript | 1500
-| [graphql-hooks](https://github.com/nearform/graphql-hooks) | JavaScript | 1000
-| [machinebox/graphql](https://github.com/machinebox/graphql) | Go | 463
-| [nanographql](https://github.com/yoshuawuyts/nanographql) | JavaScript | 357
-| [GQL](https://github.com/graphql-python/gql) | Python | 304
-| [Graphql](https://github.com/shurcooL/graphql#readme) | Go | 294
-| [re-graph](https://github.com/oliyh/re-graph/) | Clojure | 260
-| [Grafoo](https://github.com/grafoojs/grafoo) | TypeScript | 250
-| [GraphQL.Client](https://github.com/graphql-dotnet/graphql-client) | C# |  244
-| [nodes](https://github.com/americanexpress/nodes) | Java | 208
-| [sgqlc](https://github.com/profusion/sgqlc) | Python | 160
-| [python-graphql-client](https://github.com/prisma-labs/python-graphql-client) | Python | 108
+## Server implementations
 
-⭐️ accurate as of November 2019
+| Name                                                                 | Language    | ⭐️  |
+| -------------------------------------------------------------------- | ----------- | ---- |
+| [apollo-server](https://github.com/apollographql/apollo-server)      | JavaScript  | 8674 |
+| [graphql](https://github.com/graphql-go/graphql)                     | Go          | 5758 |
+| [Graphene](https://github.com/graphql-python/graphene)               | Python      | 5235 |
+| [graphql-yoga](https://github.com/prisma-labs/graphql-yoga)          | TypeScript  | 5184 |
+| [express-graphql](https://github.com/graphql/express-graphql)        | JavaScript  | 4937 |
+| [graphql-ruby](https://github.com/rmosolgo/graphql-ruby)             | Ruby        | 4058 |
+| [graphql-java](https://github.com/graphql-java/graphql-java)         | Java        | 3889 |
+| [GraphQL for .NET](https://github.com/graphql-dotnet/graphql-dotnet) | C#/.NET     | 3810 |
+| [gqlgen](https://github.com/99designs/gqlgen)                        | Go          | 3672 |
+| [graphql-php](https://github.com/webonyx/graphql-php)                | PHP         | 3474 |
+| [absinthe](https://github.com/absinthe-graphql/absinthe)             | Elixir      | 2967 |
+| [graphql-go](https://github.com/graph-gophers/graphql-go)            | Go          | 3065 |
+| [Juniper](https://github.com/graphql-rust/juniper)                   | Rust        | 2025 |
+| [Sangria](https://github.com/sangria-graphql/sangria)                | Scala       | 1647 |
+| [Lighthouse](https://github.com/nuwave/lighthouse)                   | PHP/Laravel | 1424 |
+| [lacinia](https://github.com/walmartlabs/lacinia)                    | Clojure     | 1325 |
+| [graphql-laravel](https://github.com/rebing/graphql-laravel)         | PHP/Laravel | 1066 |
+| [Thunder](https://github.com/samsarahq/thunder)                      | Go          | 930  |
+| [graphql-elixir](https://github.com/graphql-elixir/graphql)          | Elixir      | 838  |
+| [Siler](https://github.com/leocavalcante/siler)                      | PHP         | 853  |
+| [graphql-upload](https://github.com/jaydenseric/graphql-upload)      | JavaScript  | 832  |
+| [GraphQL.Net](https://github.com/chkimes/graphql-net)                | C#/.NET     | 802  |
+| [Hot Chocolate](https://github.com/ChilliCream/hotchocolate)         | C#          | 777  |
+| [koa-graphql](https://github.com/chentsulin/koa-graphql)             | JavaScript  | 728  |
+| [tartiflette](https://github.com/tartiflette/tartiflette)            | Python      | 506  |
+| [graphql-kotlin](https://github.com/ExpediaGroup/graphql-kotlin)     | Kotlin      | 377  |
+| [graphql-relay-go](https://github.com/graphql-go/relay)              | Go          | 335  |
+| [graphql-clj](https://github.com/tendant/graphql-clj)                | Clojure     | 269  |
+| [graphql-erlang](https://github.com/shopgun/graphql-erlang)          | Erlang      | 258  |
+| [Alumbra](https://github.com/alumbra/alumbra)                        | Clojure     | 136  |
 
-Note: there's also a little bit of blurring in that some of these are SDK-level client libraries and others are IDEs. 
+⭐️ Accurate as of December 2019.
+
+## Client implementations
+
+| Name                                                                          | Language   | ⭐️   |
+| ----------------------------------------------------------------------------- | ---------- | ----- |
+| [Relay](https://github.com/facebook/relay)                                    | JavaScript | 13909 |
+| [apollo-client](https://github.com/apollographql/apollo-client)               | TypeScript | 12826 |
+| [graphiql](https://github.com/graphql/graphiql)                               | JavaScript | 9712  |
+| [GraphQL Playground](https://github.com/prisma-labs/graphql-playground)       | TypeScript | 5456  |
+| [graphql-editor](https://github.com/graphql-editor/graphql-editor)            | TypeScript | 4221  |
+| [urql](https://github.com/FormidableLabs/urql)                                | TypeScript | 3920  |
+| [Apollo iOS](https://github.com/apollographql/apollo-ios)                     | Swift      | 2228  |
+| [graphql-request](https://github.com/prisma-labs/graphql-request)             | TypeScript | 2071  |
+| [apollo-android](https://github.com/apollographql/apollo-android)             | Java       | 1998  |
+| [Altair](https://github.com/imolorhe/altair)                                  | TypeScript | 1900  |
+| [Lokka](https://github.com/kadirahq/lokka)                                    | JavaScript | 1486  |
+| [graphql-hooks](https://github.com/nearform/graphql-hooks)                    | JavaScript | 1045  |
+| [graphql-react](https://github.com/jaydenseric/graphql-react)                 | JavaScript | 482   |
+| [machinebox/graphql](https://github.com/machinebox/graphql)                   | Go         | 473   |
+| [nanographql](https://github.com/yoshuawuyts/nanographql)                     | JavaScript | 360   |
+| [GQL](https://github.com/graphql-python/gql)                                  | Python     | 310   |
+| [graphql](https://github.com/shurcooL/graphql)                                | Go         | 304   |
+| [re-graph](https://github.com/oliyh/re-graph/)                                | Clojure    | 269   |
+| [GraphQL.Client](https://github.com/graphql-dotnet/graphql-client)            | C#         | 259   |
+| [Grafoo](https://github.com/grafoojs/grafoo)                                  | TypeScript | 251   |
+| [nodes](https://github.com/americanexpress/nodes)                             | Java       | 215   |
+| [sgqlc](https://github.com/profusion/sgqlc)                                   | Python     | 168   |
+| [python-graphql-client](https://github.com/prisma-labs/python-graphql-client) | Python     | 107   |
+
+⭐️ Accurate as of December 2019.


### PR DESCRIPTION
- Changed the wording to define implementations more broadly than just GraphQL servers and clients, to also include middleware, etc.
- Updated the project star counts and reordered accordingly. High star count projects now have exact numbers, not just the approximations GitHub displays.
- Listed the [`graphql-upload`](https://github.com/jaydenseric/graphql-upload), [`apollo-upload-client`](https://github.com/jaydenseric/apollo-upload-client) and [`graphql-react`](https://github.com/jaydenseric/graphql-react) projects.
- Misc. formatting tweaks and fixes.

This actions a discussion point in the [2019-12-17 meeting](https://github.com/APIs-guru/graphql-over-http/blob/master/working-group/agendas/2019-12-17.md).