### PR TITLE
Add Jayden Seric to the 2020-02-25 agenda

### DIFF
--- a/working-group/agendas/2020-02-25.md
+++ b/working-group/agendas/2020-02-25.md
@@ -21,7 +21,8 @@ This is an open meeting in which anyone in the GraphQL community may attend.
 > - Read and follow the [participation guidelines](https://github.com/graphql/graphql-wg#participation-guidelines) and [code of conduct](https://github.com/graphql/foundation/blob/master/CODE-OF-CONDUCT.md).
 
 | Name                     | Organization / Project         | Location
-| ------------------------ | ------------------------------ | ---------
+| ------------------------ | ------------------------------ | --------------------
+| Jayden Seric             | GraphQL multipart request spec | Melbourne, Australia
 | Sam Parsons              | PayPal/Braintree               | Iowa, USA
 | *ADD YOUR NAME ABOVE TO ATTEND, ORDER BY ORG THEN NAME*
 
@@ -46,5 +47,6 @@ Example agenda item:
 1. Introduction of attendees (5m)
 1. Determine volunteers for note taking (2m)
 1. Review agenda (2m)
+1. Test runner PoC progress for [#57](https://github.com/APIs-guru/graphql-over-http/issues/57) (15m)
 
 1. *ADD YOUR AGENDA ABOVE*


### PR DESCRIPTION
Also adds an agenda item: Test runner PoC progress for [#57](https://github.com/APIs-guru/graphql-over-http/issues/57).