### PR TITLE
Provide clarifications on content type and serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A server MAY support requests from clients with other content types.
 
 A client MUST handle receiving responses with HTTP header `Content-Type: application/graphql+json` since any compliant server must support this type.
 
-This header MAY include encoding information (e.g. `Content-type: application/graphql+json; charset=utf-8`)
+This header MAY include encoding information (e.g. `Content-Type: application/graphql+json; charset=utf-8`)
 
 # Request
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,11 @@ The following are the officially recognized GraphQL content types to designate e
 | `application/graphql+json` | Required
 | `application/json` | To support legacy clients
 
-Servers MUST support requests from clients with HTTP header `Content-Type: application/graphql+json`.
+A server MUST support requests from clients with HTTP header `Content-Type: application/graphql+json`.
 
-Servers MAY support requests from clients with other content types.
+A server MAY support requests from clients with other content types.
 
 A client MUST handle receiving responses with HTTP header `Content-Type: application/graphql+json` since any compliant server must support this type.
-
-If another content type is preferable to a client, it MAY include an `Accept` HTTP header listing other acceptable content types. In this case a client SHOULD include `application/graphql+json` in the list, according to their preferred priority.
-
-According to the HTTP specification, when a client does not include at least one content type supported in the `Accept` HTTP header, the server MAY choose to respond in one of several ways. The server MAY respond in a default content type and specify this in the `Content-Type` header of the response. Alternatively, it MAY respond with a `415 Unsupported Media Type` status code. See § Status Codes for detailed explanation of status codes.
 
 # Request
 
@@ -195,11 +191,16 @@ any errors encountered during the request.
 
 If the server's response contains a body it should follow the requirements for [GraphQL response](https://graphql.github.io/graphql-spec/June2018/#sec-Response).
 
-A server MUST return a `Content-Type` HTTP Header with a value of a valid GraphQL content type.
+A server MUST return a `Content-Type` HTTP Header with a value of a valid GraphQL content type. By default the response MUST be serialized as JSON and MUST include a  "Content-type: application/graphql+json` header.
 
-When sending a successful response to a client, the server SHOULD respect the given `Accept` header on the request and attempt to encode the response in the desired content type. The server MUST support a content type of `application/graphql+json`.
+If another content type is preferable to a client, it MAY include an `Accept` HTTP header listing other acceptable content types in order of preference. In this case a client SHOULD include `application/graphql+json` in the list, according to their preferred priority.
 
 If no `Accept` header is given, the server MUST respond with a content type of `application/graphql+json`.
+
+The server MUST respect the given `Accept` header and attempt to encode the respond in the first supported content type listed. According to the [HTTP 1.1 Accept](https://tools.ietf.org/html/rfc7231#section-5.3.2) specification, when a client does not include at least one supported content type in the `Accept` HTTP header, the server MAY choose to respond in one of several ways. The server MUST either:
+
+1. Disregard the `Accept` header and respond with the default content type of `application/graphql`, specifying this in the `Content-type` header; OR
+2. Respond with a `406 Not Acceptable` status code
 
 Note: For any non-2XX response, the client should not rely on the body to be in GraphQL format since the source of the response
 may not be the GraphQL server but instead some intermediary such as API gateways, firewalls, etc.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This header MAY include encoding information (e.g. `Content-Type: application/gr
 
 # Request
 
-A server MUST accept either GET requests or POST requests.
+A server MUST accept POST requests, and MAY accept other HTTP methods, such as GET.
 
 A server SHOULD handle both GET and POST requests.
 
@@ -134,7 +134,7 @@ Servers MUST return an _Error response_ if a GET request includes a `query` and 
 
 Clients MUST NOT send GET requests for non-query operations.
 
-Clients SHOULD NOT send a `Content-type` header on a GET request.
+Clients SHOULD NOT send a `Content-Type` header on a GET request.
 
 ### Example
 
@@ -166,11 +166,9 @@ Note: `query` and `operationName` parameters are encoded as raw strings in the q
 
 ## POST
 
-A GraphQL POST request instructs the server to perform a query, mutation or subscription operation. A GraphQL POST request should have a body which contains values of the request parameters encoded according to the value of `Content-Type` header of the request.
+A GraphQL POST request instructs the server to perform a query, mutation or subscription operation. A GraphQL POST request MUST have a body which contains values of the request parameters encoded according to the value of `Content-Type` header of the request.
 
-When sending a POST request to a GraphQL server a client MUST include a body.
-
-A client MUST include a `content-type` with a POST request.
+A client MUST include a `Content-Type` with a POST request.
 
 ### Example
 
@@ -193,7 +191,7 @@ any errors encountered during the request.
 
 If the server's response contains a body it should follow the requirements for [GraphQL response](https://graphql.github.io/graphql-spec/June2018/#sec-Response).
 
-A server MUST return a `Content-Type` HTTP Header with a value of a valid GraphQL content type. By default the response MUST be serialized as JSON and MUST include a  "Content-type: application/graphql+json` header.
+A server MUST return a `Content-Type` HTTP Header with a value of a valid GraphQL content type. By default the response MUST be serialized as JSON and MUST include a  "Content-Type: application/graphql+json` header.
 
 If another content type is preferable to a client, it MAY include an `Accept` HTTP header listing other acceptable content types in order of preference. In this case a client SHOULD include `application/graphql+json` in the list, according to their preferred priority.
 
@@ -201,7 +199,7 @@ If no `Accept` header is given, the server MUST respond with a content type of `
 
 The server MUST respect the given `Accept` header and attempt to encode the respond in the first supported content type listed. According to the [HTTP 1.1 Accept](https://tools.ietf.org/html/rfc7231#section-5.3.2) specification, when a client does not include at least one supported content type in the `Accept` HTTP header, the server MAY choose to respond in one of several ways. The server MUST either:
 
-1. Disregard the `Accept` header and respond with the default content type of `application/graphql`, specifying this in the `Content-type` header; OR
+1. Disregard the `Accept` header and respond with the default content type of `application/graphql+json`, specifying this in the `Content-Type` header; OR
 2. Respond with a `406 Not Acceptable` status code
 
 Note: For any non-2XX response, the client should not rely on the body to be in GraphQL format since the source of the response

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It is recommended to end the path component of the URL with `/graphql`, for exam
 
 # Serialization Format
 
-The GraphQL specification allows for many [serialization formats to be implemented](https://spec.graphql.org/June2018/#sec-Serialization-Format). In practice JSON is the most common serialization format. In order to be compliant, servers and clients implementing GraphQL over HTTP must support JSON serialization.
+The GraphQL specification allows for many [serialization formats to be implemented](https://spec.graphql.org/June2018/#sec-Serialization-Format). Servers and clients over HTTP MUST support JSON and MAY support other, additional serialization formats.
 
 ## Content Types
 
@@ -99,7 +99,7 @@ A server MAY support requests from clients with other content types.
 
 A client MUST handle receiving responses with HTTP header `Content-Type: application/graphql+json` since any compliant server must support this type.
 
-This header MAY include encoding information (e.g. `Content-type: application/json; charset=utf-8`)
+This header MAY include encoding information (e.g. `Content-type: application/graphql+json; charset=utf-8`)
 
 # Request
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ The following are the officially recognized GraphQL content types to designate e
 | `application/graphql+json` | Required
 | `application/json` | To support legacy clients
 
-A server MUST support requests from clients with HTTP header `Content-Type: application/graphql+json`.
+A server MUST support requests from clients with HTTP header `Content-Type: application/graphql+json` indicating that the body of the request is a JSON document with a GraphQL request. A server must indicate the content type of the response with a `Content-Type` header. This default value should be `Content-Type: application/graphql+json` indicating that the response is a valid JSON document containing at least one of the `data` or `errors` as a top-level attribute.
 
 A server MAY support requests from clients with other content types.
 
 A client MUST handle receiving responses with HTTP header `Content-Type: application/graphql+json` since any compliant server must support this type.
+
+This header MAY include encoding information (e.g. `Content-type: application/json; charset=utf-8`)
 
 # Request
 


### PR DESCRIPTION
This PR introduces some new rules in addition to addressing clarifications on the behavior of servers and clients with response to content types. 

Most notably:

1. Specifies that servers MUST support JSON serialization and the associated `application/graphl+json` content type.
2. Describes how servers and clients should interact with respect to content types.
3. Separates examples in both GET and POST requests to their own section heading

