### PR TITLE
Add EasyCLA info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ The GraphQL over HTTP specification is edited in the [spec-md markdown file](./s
 
 In the future, we plan that you would be able to view the generated form of the specification as well.
 
+### Contributing to this repo
+
+This repository is managed by EasyCLA. Project participants must sign the free ([GraphQL Specification Membership agreement](https://preview-spec-membership.graphql.org) before making a contribution. You only need to do this one time, and it can be signed by [individual contributors](http://individual-spec-membership.graphql.org/) or their [employers](http://corporate-spec-membership.graphql.org/).
+
+To initiate the signature process please open a PR against this repo. The EasyCLA bot will block the merge if we still need a membership agreement from you.
+
+You can find [detailed information here](https://github.com/graphql/graphql-wg/tree/main/membership). If you have issues, please email [operations@graphql.org](mailto:operations@graphql.org).
+
+If your company benefits from GraphQL and you would like to provide essential financial support for the systems and people that power our community, please also consider membership in the [GraphQL Foundation](https://foundation.graphql.org/join).
+
 ---
 Copyright Joint Development Foundation Projects, LLC, GraphQL Series.<br>
 [graphql.org](https://graphql.org) | [Spec](https://spec.graphql.org) | [GitHub](https://github.com/graphql/graphql-over-http) | [GraphQL Foundation](https://foundation.graphql.org) | [Code of Conduct](https://code-of-conduct.graphql.org) | [Slack](https://graphql.slack.com/archives/CRTKLUZRT) | [Store](https://store.graphql.org)


### PR DESCRIPTION
This is a trivial PR that adds info on using EasyCLA to ensure that everyone has signed the spec membership agreement. I'll merge it directly.

Signed-off-by: Brian Warner <brian@bdwarner.com>