### PR TITLE
Update Zoom link in today's agenda

### DIFF
--- a/working-group/agendas/2023/2023-10-26.md
+++ b/working-group/agendas/2023/2023-10-26.md
@@ -80,8 +80,8 @@ This is an open meeting in which anyone in the GraphQL community may attend.
   - _Please Note:_ The date or time may change. Please check this agenda the
     week of the meeting to confirm. While we try to keep all calendars accurate,
     this agenda document is the source of truth.
-- **Video Conference Link**: https://zoom.us/j/99185628116
-  - _Password:_ httpwg
+- **Video Conference Link**: https://zoom.us/j/92781382543?pwd=R2RtVWV4SlQybGYzVXArSjU5WjBzUT09
+  - _Password:_ graphqlwg
 - **Live Notes**:
   [Google Doc](https://docs.google.com/document/d/1hUi3kSdcINQLWD6s8DBZIwepnqy51dwPZShDn8c1GZU/edit?usp=sharing)
 


### PR DESCRIPTION
No idea why the old one expired.