### PR TITLE
Add a section about the HTTP protocol

### DIFF
--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -120,9 +120,7 @@ time.
 # HTTP protocol
 
 A server MUST comply with
-[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231) semantics. In this
-document, the words "header", "Content-Type" and "status code" refer to
-[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
+[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231) semantics.
 
 A server MUST support at least one version of the HTTP message format, such as
 [1.1](https://datatracker.ietf.org/doc/html/rfc7230) or
@@ -260,7 +258,8 @@ be part of a well-formed _GraphQL-over-HTTP request_.
 ## Accept
 
 A client MUST indicate the media types that it supports in responses using the
-`Accept` HTTP header.
+`Accept` HTTP header as specified in
+[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
 
 Note: If a client does not supply the `Accept` header then the server may
 respond with an error, or with any content type it chooses (including serving a
@@ -349,7 +348,7 @@ _GraphQL-over-HTTP request_ parameters encoded in one of the officially
 recognized GraphQL media types, or another media type supported by the server.
 
 A client MUST indicate the media type of a request body using the `Content-Type`
-header.
+header as specified in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
 
 A server MUST support POST requests encoded with the `application/json` media
 type (as indicated by the `Content-Type` header) encoded with UTF-8.

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -117,6 +117,17 @@ interact with a _GraphQL service_.
 Note: GraphQL Subscriptions are beyond the scope of this specification at this
 time.
 
+# HTTP protocol
+
+A server MUST support the HTTP 1.1 protocol as described in
+[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
+
+A server MAY support other versions of the HTTP protocol.
+
+This specification assumes that all versions of the HTTP protocol have "header",
+"Content-Type" and "status codes". These terms are to be interpreted according
+to their respective HTTP specification.
+
 # URL
 
 A _server_ MUST enable GraphQL requests to one or more GraphQL schemas.
@@ -246,8 +257,7 @@ be part of a well-formed _GraphQL-over-HTTP request_.
 ## Accept
 
 A client MUST indicate the media types that it supports in responses using the
-`Accept` HTTP header as specified in
-[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
+`Accept` HTTP header.
 
 Note: If a client does not supply the `Accept` header then the server may
 respond with an error, or with any content type it chooses (including serving a
@@ -336,7 +346,7 @@ _GraphQL-over-HTTP request_ parameters encoded in one of the officially
 recognized GraphQL media types, or another media type supported by the server.
 
 A client MUST indicate the media type of a request body using the `Content-Type`
-header as specified in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
+header.
 
 A server MUST support POST requests encoded with the `application/json` media
 type (as indicated by the `Content-Type` header) encoded with UTF-8.

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -119,14 +119,17 @@ time.
 
 # HTTP protocol
 
-A server MUST support the HTTP 1.1 protocol as described in
+A server MUST comply with
+[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231) semantics. In this
+document, the words "header", "Content-Type" and "status code" refer to
 [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
 
-A server MAY support other versions of the HTTP protocol.
+A server MUST support at least one version of the HTTP message format, such as
+[1.1](https://datatracker.ietf.org/doc/html/rfc7230) or
+[2.0](https://www.rfc-editor.org/rfc/rfc9113).
 
-This specification assumes that all versions of the HTTP protocol have "header",
-"Content-Type" and "status codes". These terms are to be interpreted according
-to their respective HTTP specification.
+A server MAY support several versions of the HTTP message format for wider
+compatibility.
 
 # URL
 

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -123,8 +123,8 @@ A server MUST comply with
 [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231) semantics.
 
 A server MUST support at least one version of the HTTP message format, such as
-[1.1](https://datatracker.ietf.org/doc/html/rfc7230) or
-[2.0](https://www.rfc-editor.org/rfc/rfc9113).
+[HTTP/1.1](https://datatracker.ietf.org/doc/html/rfc7230) or
+[HTTP/2](https://datatracker.ietf.org/doc/html/rfc9113).
 
 A server MAY support several versions of the HTTP message format for wider
 compatibility.

--- a/spec/GraphQLOverHTTP.md
+++ b/spec/GraphQLOverHTTP.md
@@ -119,8 +119,15 @@ time.
 
 # HTTP protocol
 
-A server MUST comply with
+The details of the HTTP protocol used by GraphQL clients and servers are outside
+this specification.
+
+Where applicable, server and clients MUST comply with
 [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231) semantics.
+
+In particular, "header", "status code", "body", "Accept", and "Content-Type" are
+to be interpreted according to
+[RFC7231](https://datatracker.ietf.org/doc/html/rfc7231).
 
 A server MUST support at least one version of the HTTP message format, such as
 [HTTP/1.1](https://datatracker.ietf.org/doc/html/rfc7230) or


### PR DESCRIPTION
The current spec mentions HTTP 1.1 everywhere so I guess this is a requirement? But we might want to allow HTTP 2.0 still?