### PR TITLE
Add "persisted documents by default" to April agenda

### DIFF
--- a/working-group/agendas/2026/04-Apr/30-graphql-over-http-wg-april-2026.md
+++ b/working-group/agendas/2026/04-Apr/30-graphql-over-http-wg-april-2026.md
@@ -118,5 +118,7 @@ We typically meet on the last Thursday of the month.
 1. Review agenda (2m, Host)
 1. Check for [ready for review agenda items](https://github.com/graphql/graphql-over-http/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)
 1. Reminder: [grants available for key initiatives](https://graphql.org/community/foundation/community-grant/) (1m, Host)
-2. Appendix A: `application/json`
+1. Appendix A: `application/json` (20m, Martin)
    - https://github.com/graphql/graphql-over-http/pull/379
+1. Persisted documents by default? (20m, Benjie)
+   - https://github.com/graphql/graphql-over-http/issues/392


### PR DESCRIPTION
Since we're considering making the spec a breaking change versus the status quo, let's make it impactful.