### PR TITLE
Update attendee list and add agenda items

### DIFF
--- a/working-group/agendas/2026/06-Jun/25-graphql-over-http-wg-june-2026.md
+++ b/working-group/agendas/2026/06-Jun/25-graphql-over-http-wg-june-2026.md
@@ -102,6 +102,7 @@ We typically meet on the last Thursday of the month.
 | Name                 | GitHub        | Organization       | Location              |
 | :------------------- | :------------ | :----------------- | :-------------------- |
 | Benjie Gillam (Host) | @benjie       | Graphile           | Chandler's Ford, UK   |
+| Martin Bonnin | @martinbonnin       | Apollo           | Paris, FR   |
 
 
 ## Agenda
@@ -117,3 +118,6 @@ We typically meet on the last Thursday of the month.
 1. Review agenda (2m, Host)
 1. Check for [ready for review agenda items](https://github.com/graphql/graphql-over-http/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc) (5m, Host)
 1. Reminder: [grants available for key initiatives](https://graphql.org/community/foundation/community-grant/) (1m, Host)
+1. HTTP `QUERY` verb
+   - thoughts? Should we do this?
+1. https://github.com/graphql/graphql-over-http/pull/404


### PR DESCRIPTION
Added Martin Bonnin to the attendee list and included a new agenda item regarding the HTTP `QUERY` verb.