### PR TITLE
Remove automatic host assignment

### DIFF
--- a/wg.config.js
+++ b/wg.config.js
@@ -18,7 +18,6 @@ const config = {
   attendeesTemplate: `\
 | Name                 | GitHub        | Organization       | Location              |
 | :------------------- | :------------ | :----------------- | :-------------------- |
-| Benjie Gillam (Host) | @benjie       | Graphile           | Chandler's Ford, UK   |
 `,
   dateAndTimeLocations:
     "&p1=3775&p2=110&p3=24&p4=37&p5=188&p6=496&p7=676&p8=438&p9=268&p10=234&p11=78&p12=604",

--- a/working-group/agendas/2026/07-Jul/30-graphql-over-http-wg-july-2026.md
+++ b/working-group/agendas/2026/07-Jul/30-graphql-over-http-wg-july-2026.md
@@ -101,7 +101,6 @@ We typically meet on the last Thursday of the month.
 <!-- prettier-ignore -->
 | Name                 | GitHub        | Organization       | Location              |
 | :------------------- | :------------ | :----------------- | :-------------------- |
-| Benjie Gillam (Host) | @benjie       | Graphile           | Chandler's Ford, UK   |
 
 
 ## Agenda

--- a/working-group/agendas/2026/08-Aug/27-graphql-over-http-wg-august-2026.md
+++ b/working-group/agendas/2026/08-Aug/27-graphql-over-http-wg-august-2026.md
@@ -101,7 +101,6 @@ We typically meet on the last Thursday of the month.
 <!-- prettier-ignore -->
 | Name                 | GitHub        | Organization       | Location              |
 | :------------------- | :------------ | :----------------- | :-------------------- |
-| Benjie Gillam (Host) | @benjie       | Graphile           | Chandler's Ford, UK   |
 
 
 ## Agenda

--- a/working-group/agendas/2026/09-Sep/24-graphql-over-http-wg-september-2026.md
+++ b/working-group/agendas/2026/09-Sep/24-graphql-over-http-wg-september-2026.md
@@ -101,7 +101,6 @@ We typically meet on the last Thursday of the month.
 <!-- prettier-ignore -->
 | Name                 | GitHub        | Organization       | Location              |
 | :------------------- | :------------ | :----------------- | :-------------------- |
-| Benjie Gillam (Host) | @benjie       | Graphile           | Chandler's Ford, UK   |
 
 
 ## Agenda


### PR DESCRIPTION
We've moved away from this practice, the host now manually adds themselves to the agenda to help avoid issues surrounding late addition of agenda items.